### PR TITLE
Add username

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -45,8 +45,8 @@
 
       <h3>2. Add remote repository</h3>
 
-      <pre>$ git remote add paus git@git.wantedlyapp.com:&lt;repository&gt;</pre>
-      <p class="help-block" style="font-size: 12px;">ex.$ git remote add paus git@git.wantedlyapp.com:spring-intern-2016-api-samples</p>
+      <pre>$ git remote add paus git@git.wantedlyapp.com:&lt;username/repository&gt;</pre>
+      <p class="help-block" style="font-size: 12px;">ex.$ git remote add paus git@git.wantedlyapp.com:koudaiii/spring-intern-2016-api-samples</p>
 
       <h3>3. <code>git push</code> </h3>
 


### PR DESCRIPTION
## WHY

gitreceive でgit init されていることがわかり、複数人で同じリポジトリ URL で remote add してしまうと、push したタイミングで reject されてしまうことがわかった。

※都度 push したら tar を送っていると思っていたので、何回 push しても大丈夫だと思っていた。そうではないというのを文言に追加させたい。
## WHAT
- この話をしっているのはあくまでも前回の速習会に参加していたメンバーのみのため、今回意図的にURL が被らないように `<username/repogistry>` という文言に変えてレポジトリが被らないように文言を修正した。
