### PR TITLE
URL一覧ページの追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !glide.yaml
 !templates/
 !bin/paus-frontend
+!etcd-ls.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 ENV DOCKER_COMPOSE_VERSION 1.6.0
 ENV GLIBC_VERSION 2.22-r8
 ENV GLIDE_VERSION 0.8.3
+ENV ETCD_VERSION 2.2.5
 
 RUN apk --update add ca-certificates docker && \
     wget -O /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Linux-x86_64 && \
@@ -15,6 +16,12 @@ RUN apk --update add ca-certificates docker && \
     rm glibc.apk glibc-bin.apk && \
     apk del --purge ca-certificates && \
     rm -rf /var/cache/apk/*
+
+RUN wget -qO /tmp/etcd-v$ETCD_VERSION-linux-amd64.tar.gz https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz && \
+    cd /tmp && \
+    tar zxf etcd-v$ETCD_VERSION-linux-amd64.tar.gz && \
+    cp etcd-v$ETCD_VERSION-linux-amd64/etcdctl /usr/local/bin/etcdctl && \
+    rm -rf etcd-v$ETCD_VERSION-linux-amd64.tar.gz etcd-v$ETCD_VERSION-linux-amd64
 
 COPY . /go/src/github.com/dtan4/paus
 RUN apk --update add git go make mercurial && \
@@ -28,6 +35,7 @@ RUN apk --update add git go make mercurial && \
     glide install && \
     make build && \
     mkdir /app && \
+    cp etcd-ls.sh /app/etcd-ls.sh && \
     cp bin/paus-frontend /app/paus-frontend && \
     cp -R templates /app/templates && \
     cd /app && \

--- a/etcd-ls.sh
+++ b/etcd-ls.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+export ETCDCTL_ENDPOINT=http://`ip route show 0.0.0.0/0 | grep -Eo 'via \S+' | awk '{ print $2 }'`:2379
+
+etcdctl ls --sort /vulcand/frontends

--- a/main.go
+++ b/main.go
@@ -20,6 +20,36 @@ func main() {
 		})
 	})
 
+  // NOTE:
+  // URL一覧を表示する。
+  // go用のetcdクライアントは存在するがetcdctl lsが使えないため、
+  // shellscriptで対応した。
+  // https://github.com/coreos/etcd/tree/master/client
+  r.GET("/urls", func(c *gin.Context) {
+    cmd := exec.Command("sh", "etcd-ls.sh")
+    stdout, err := cmd.StdoutPipe()
+
+    if err != nil {
+      c.HTML(http.StatusOK, "urls.tmpl", gin.H{
+        "error":   true,
+        "message": strings.Join([]string{"error: ", err.Error()}, ""),
+      })
+    } else {
+      cmd.Start()
+      scanner := bufio.NewScanner(stdout)
+      rep := regexp.MustCompile(`/vulcand/frontends/`)
+      url := make([]string, 0)
+      for scanner.Scan() {
+        url = append(url, rep.ReplaceAllString(scanner.Text(), ""))
+      }
+      c.HTML(http.StatusOK, "urls.tmpl", gin.H{
+        "error":   false,
+        "url":     url,
+      })
+      cmd.Wait()
+    }
+  })
+
 	r.POST("/submit", func(c *gin.Context) {
 		username := c.PostForm("username")
 		pubKey := c.PostForm("pubKey")

--- a/templates/urls.tmpl
+++ b/templates/urls.tmpl
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Paus</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="container">
+      <h1>URL list</h1>
+      {{ if .error }}
+      <div class="alert alert-danger" role="alert">
+        {{ .message }}
+      </div>
+      {{ else }}
+      <div class="list-group">
+        {{ range .url }}<a class="list-group-item" href="https://{{ . }}.wantedlyapp.com">https://{{ . }}.wantedlyapp.com</a>{{ end }}
+      {{ end }}
+      </div>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-2.2.0.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+  </body>
+</html>


### PR DESCRIPTION
## REF

https://github.com/wantedly/infrastructure/issues/854
## WHY

生成されたURLの確認方法が現状デプロイ時のみであり、忘れた時点で前のコンテナへアクセスする方法がなくなる。
そのためURL一覧ページを追加する。
## WHAT
- paus.wantedlyapp.com/urls を追加
- etcdをインストールするようにDockerfileを修正
