### PR TITLE
Install dependencies by `make deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build: clean
 clean:
 	rm -f bin/paus-frontend
 
+deps:
+	go get -u github.com/Masterminds/glide
+	glide install
+
 docker-build: clean
 	docker build -f Dockerfile.build -t quay.io/dtan4/paus-frontend:latest .
 


### PR DESCRIPTION
## WHY

paus-frontend requires glide for dependency management.
## WHAT

Create `make deps` task to install glide itself and dependencies of paus-frontend.
