### PR TITLE
Modify docker-build task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ deps:
 	glide install
 
 docker-build: clean
-	docker build -f Dockerfile.build -t quay.io/dtan4/paus-frontend:latest .
+	docker build -t quay.io/dtan4/paus-frontend:latest .
 
 .PHONY: build clean docker-build


### PR DESCRIPTION
## WHY

`make docker-build` task fails now, because `Dockerfile.build` no longer exists.
## WHAT

Modiffy `docker-build` task to complete successfully.
